### PR TITLE
Do not show presentations from public/talks

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -25,7 +25,7 @@
 
 [[main]]
   name = "Presentations"
-  url = "/talk/"
+  url = "#talks"
   weight = 5
 
 [[main]]


### PR DESCRIPTION
Replace `/talks/` by `#talk` to use the content in _content/home/talks.md_ instead of the one in _public/talks/_